### PR TITLE
GTK-warning fix which requires using size units

### DIFF
--- a/gtk-3.0/gtk.css
+++ b/gtk-3.0/gtk.css
@@ -8150,7 +8150,7 @@ GraniteWidgetsPopOver {
     -GraniteWidgetsPopOver-border-width: 1;
     -GraniteWidgetsPopOver-shadow-size: 12;
     border-radius: 2px;
-    border-width: 1;
+    border-width: 1px;
     border: 1px solid rgba(0, 0, 0, 0.3);
     margin: 0;
 }


### PR DESCRIPTION
Hello. Without this fix I could not start Telegram-desktop application, every time the start was failed:

Gtk-WARNING **: 19:50:45.653: Theme parsing error: gtk.css:8153:19: Not using units is deprecated. Assuming 'px'.
QApplication: invalid style override passed, ignoring it.
