### PR TITLE
Fixes transparent dropdown in e.g. epiphany

### DIFF
--- a/gtk-3.0/gtk-red.css
+++ b/gtk-3.0/gtk-red.css
@@ -16,6 +16,8 @@
     }
 }
 
+@define-color content_view_bg #242424;
+
 * {
     background-clip: padding-box;
     -GtkToolButton-icon-spacing: 4;

--- a/gtk-3.0/gtk.css
+++ b/gtk-3.0/gtk.css
@@ -16,6 +16,8 @@
     }
 }
 
+@define-color content_view_bg #242424;
+
 * {
     background-clip: padding-box;
     -GtkToolButton-icon-spacing: 4;

--- a/gtk-3.0/gtk_blue.css
+++ b/gtk-3.0/gtk_blue.css
@@ -16,6 +16,8 @@
     }
 }
 
+@define-color content_view_bg #242424;
+
 * {
     background-clip: padding-box;
     -GtkToolButton-icon-spacing: 4;


### PR DESCRIPTION
The variable content_view_bg was undefined, resulting in a transparent dropdown for the address bar in gnome web (epiphany). The text in the box is white, which makes it illegible in a transparent dropdown.