### PR TITLE
Update gnome-shell.css

### DIFF
--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -754,7 +754,7 @@ StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu .popup-menu-item:ltr {
-    padding: 0.4em 24px 0.4em 0;
+    margin: 0.1em 0 0.1em 0;
 }
 
 .popup-menu .popup-menu-item:rtl {


### PR DESCRIPTION
Removes the padding from ".popup-menu .po,pup-menu-item:ltr" to remove that ugly grey space around the divider, to show only said divider.